### PR TITLE
Clone submodules in appveyor script.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,6 +12,7 @@ environment:
       TOX_ENV: "py36"
 
 install:
+  - git submodule update --init --recursive
   - "%PYTHON%\\python.exe -m pip install tox"
 
 build: off


### PR DESCRIPTION
Make sure submodules are cloned in appveyor. This is important for the xml PR where there is a required submodule.