### PR TITLE
Set only master in appveyor.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,9 @@
 # Adapted from https://packaging.python.org/en/latest/appveyor/
 
+branches:
+  only:
+  - master
+
 environment:
   matrix:
     # only run 2 tests, these take 3 minutes each

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "Modelica"]
-	path = Modelica
-	url = https://github.com/modelica/Modelica.git


### PR DESCRIPTION
The prevents appveyor from wasting time building branches that are not master. It will still build pull request merges with master.